### PR TITLE
Mudar o status para 'invoice_issued'

### DIFF
--- a/functions/lib/integration/parsers/order-to-ecomplus/index.js
+++ b/functions/lib/integration/parsers/order-to-ecomplus/index.js
@@ -49,6 +49,7 @@ module.exports = (blingOrder, shippingLines) => {
         }
         shippingLine.invoices.push(invoice)
         partialOrder.shipping_lines = shippingLines
+        partialOrder.fulfillment_status.current = 'invoice_issued'
       }
     }
   }


### PR DESCRIPTION
Eu sei que existe um parse apenas para status, mas seria interessante, quando entrar o invoice, o status do pedido mudar para invoice issued.
Sugestão comunidade